### PR TITLE
Update NVIDIA Driver Version and Add SSD Boot Flexibility to Host Install Guide  

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Paypal  PayPal.Me/cryptolabsZA
 ## Host install guide for vast.ai 
 
 ```
+#Start with a clean install of ubuntu 22.04.x HWE Kernal server. Just add openssh.
 sudo apt update && sudo apt upgrade -y && sudo apt dist-upgrade -y && sudo apt install update-manager-core -y
 #if you did not install HWE kernal do the following  
 sudo apt install --install-recommends linux-generic-hwe-22.04 -y

--- a/README.md
+++ b/README.md
@@ -41,19 +41,17 @@ Paypal  PayPal.Me/cryptolabsZA
 ## Host install guide for vast.ai 
 
 ```
-#Start with a clean install of ubuntu 22.04.x HWE Kernal server. Just add openssh.
 sudo apt update && sudo apt upgrade -y && sudo apt dist-upgrade -y && sudo apt install update-manager-core -y
 #if you did not install HWE kernal do the following  
 sudo apt install --install-recommends linux-generic-hwe-22.04 -y
 sudo reboot
-
 #install the drivers.
 sudo apt install build-essential -y
 sudo add-apt-repository ppa:graphics-drivers/ppa -y
 sudo apt update
 # to search for available NVIDIA drivers: use this command 
 sudo apt search nvidia-driver | grep nvidia-driver | sort -r
-sudo apt install nvidia-driver-560  -y    # assuming the latest is 560
+sudo apt install nvidia-driver-570  -y    # assuming the latest is 570. Use nvidia-driver-570-open for blackwell architecture gpus
 
 #Remove unattended-upgrades Package so that the dirver don't upgrade when you have clients
 sudo apt purge --auto-remove unattended-upgrades -y
@@ -73,7 +71,8 @@ bash -c 'sudo apt-get update; sudo apt-get -y upgrade; sudo apt-get install -y l
 echo -e "n\n\n\n\n\n\nw\n" | sudo cfdisk /dev/nvme0n1 && sudo mkfs.xfs /dev/nvme0n1p1 
 sudo mkdir /var/lib/docker
 
-#I added discard so that the ssd is trimeds by ubunut and nofail if there is some problem with the drive the system will still boot.  
+# I added discard so that the ssd is trimeds by ubuntu and nofail if there is some problem with the drive the system will still boot.  
+# You must ensure your nvme disk is properly partitioned and formatted with the XFS file system.
 sudo bash -c 'uuid=$(sudo xfs_admin -lu /dev/nvme0n1p1  | sed -n "2p" | awk "{print \$NF}"); echo "UUID=$uuid /var/lib/docker/ xfs rw,auto,pquota,discard,nofail 0 0" >> /etc/fstab'
 
 sudo mount -a
@@ -87,6 +86,9 @@ sudo bash -c '(crontab -l; echo "@reboot nvidia-smi -pm 1" ) | crontab -'
 #run the install command for vast
 sudo apt install python3 -y
 sudo wget https://console.vast.ai/install -O install; sudo python3 install YourKey; history -d $((HISTCMD-1)); 
+
+# Add the flag --no-partitioning if decided to boot from a ssd
+sudo wget https://console.vast.ai/install -O install; sudo python3 install --no-partitioning; history -d $((HISTCMD-1));
 
 nano /etc/default/grub   # find the GRUB_CMDLINE_LINUX="" and ensure it looks like this. 
 GRUB_CMDLINE_LINUX="amd_iommu=on nvidia_drm.modeset=0 systemd.unified_cgroup_hierarchy=false"


### PR DESCRIPTION
This PR updates the host install guide for Vast.ai with the following key changes:  

1. **NVIDIA Driver Upgrade:**  
   - Updated the NVIDIA driver version from `nvidia-driver-560` to `nvidia-driver-570` to ensure compatibility with newer hardware.  
   - Added a note to use `nvidia-driver-570-open` for Blackwell architecture GPUs, providing clarity for users with specific hardware.  

2. **Improved Disk Partitioning Guidance:**  
   - Added a comment emphasizing the importance of proper NVMe disk partitioning and XFS formatting to avoid potential boot issues.  

3. **Enhanced Installation Flexibility:**  
   - Introduced a new install command with the `--no-partitioning` flag, allowing users to boot directly from an SSD without manual partitioning steps. This simplifies the workflow for SSD-based setups.  

4. **Minor Documentation Improvements:**  
   - Clarified comments in the script for better readability and user guidance.  

These updates improve compatibility, reduce potential user errors, and offer greater flexibility for different hardware configurations. Let me know if further adjustments are needed!